### PR TITLE
Allowed end-developers to install @embroider/try

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "license": "MIT",
   "author": "Edward Faulkner <edward@eaf4.com>",
   "type": "module",
-  "bin": "cli.js",
+  "bin": {
+    "embroider-try": "cli.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Background

The [`README` for `v1.0.1`](https://github.com/embroider-build/try/blob/v1.0.1-%40embroider/try/README.md#list) claims that one can run `pnpm @embroider/try`, but this isn't possible (to my knowledge) due to the package name starting with `@`.

By providing an alias, we can provide end-developers the option to install `@embroider/try` in a package as a development dependency. (That is, they can fix the version and don't have to use npx, pnpx, etc.)

```sh
pnpm embroider-try <options>
```
