### PR TITLE
Add shebang for Node.js execution

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { resolve, dirname } from "node:path";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { pathToFileURL } from "node:url";


### PR DESCRIPTION
if using npx instead of pnpm dlx, you get a syntax error without this?

https://discord.com/channels/480462759797063690/717767358743183412/1479130782982344837